### PR TITLE
Disable & remove region config

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -1,7 +1,7 @@
 provider: xyz
 env:
   PULUMI_MISSING_DOCS_ERROR: true
-  XYZ_REGION: "us-west-2"
+  # XYZ_REGION: "us-west-2"
 makeTemplate: bridged
 pulumiConvert: 1
 goBuildParallelism: 2

--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -19,7 +19,6 @@ env:
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
-  XYZ_REGION: us-west-2
 jobs:
   command-dispatch-for-testing:
     name: command-dispatch-for-testing

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -26,7 +26,6 @@ env:
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
-  XYZ_REGION: us-west-2
 
 jobs:
   license_check:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,6 @@ env:
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
-  XYZ_REGION: us-west-2
 
 jobs:
   lint:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -19,7 +19,6 @@ env:
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
-  XYZ_REGION: us-west-2
 jobs:
   build_sdk:
     name: build_sdk

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -20,7 +20,6 @@ env:
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
-  XYZ_REGION: us-west-2
 jobs:
   build_sdk:
     name: build_sdk

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,7 +19,6 @@ env:
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
-  XYZ_REGION: us-west-2
 jobs:
   comment-on-pr:
     if: github.event.pull_request.head.repo.full_name != github.repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ env:
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
-  XYZ_REGION: us-west-2
 jobs:
   build_sdk:
     name: build_sdk
@@ -32,16 +31,18 @@ jobs:
     needs: tag_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-      name: Dispatch Event
-      run: pulumictl create docs-build pulumi-xyz
-        "${GITHUB_REF#refs/tags/}"
+      - name: Dispatch Metadata build
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          repository: pulumi/registry
+          event-type: resource-provider
+          client-payload: |-
+            {
+              "project": "${{ github.repository }}",
+              "project-shortname": "xyz",
+              "ref": "${{ github.ref_name }}"
+            }
   lint:
     name: lint
     uses: ./.github/workflows/lint.yml

--- a/.github/workflows/resync-build.yml
+++ b/.github/workflows/resync-build.yml
@@ -21,7 +21,6 @@ env:
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
-  XYZ_REGION: us-west-2
 jobs:
   resync_build:
     name: resync-build

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -20,7 +20,6 @@ env:
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
-  XYZ_REGION: us-west-2
 
 # This should cancel any previous runs of the same workflow on the same branch which are still running.
 concurrency:

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -92,13 +92,14 @@ func Provider() tfbridge.ProviderInfo {
 		GitHubOrg:        "",
 		UpstreamRepoPath: "github.com/iwahbe/terraform-provider-xyz",
 		MetadataInfo:     tfbridge.NewProviderMetadata(metadata),
-		Config: map[string]*tfbridge.SchemaInfo{
-			"region": {
-				Type: tfbridge.MakeResource(mainPkg, "region", "Region"),
-				Default: &tfbridge.DefaultInfo{
-					EnvVars: []string{"XYZ_REGION", "XYZ_DEFAULT_REGION"},
-				},
-			},
+		Config:           map[string]*tfbridge.SchemaInfo{
+			// TODO: Implement region in the upstream provider so it doesn't error when set.
+			// "region": {
+			// 	Type: tfbridge.MakeResource(mainPkg, "region", "Region"),
+			// 	Default: &tfbridge.DefaultInfo{
+			// 		EnvVars: []string{"XYZ_REGION", "XYZ_DEFAULT_REGION"},
+			// 	},
+			// },
 		},
 		PreConfigureCallback: preConfigureCallback,
 		Resources: map[string]*tfbridge.ResourceInfo{


### PR DESCRIPTION
This is not implemented in the underlying TF provider so causes an exception. The tests only pass because they don't pass the CI env down to the test environment.

There is a new version of the upstream TF provider available, but upgrading causes the build to fail with:

```
(cd provider && go build -p 2 -o /Users/dan/Dev/pulumi-xyz/bin/pulumi-tfgen-xyz -ldflags "-X github.com/pulumi/pulumi-xyz/provider/pkg/version.Version=1.0.0-alpha.0+dev" github.com/pulumi/pulumi-xyz/provider/cmd/pulumi-tfgen-xyz)
# github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema
../../../go/pkg/mod/github.com/pulumi/terraform-plugin-sdk/v2@v2.0.0-20230912190043-e6d96b3b8f7e/helper/schema/provider.go:511:9: cannot use NewGRPCProviderServer(p) (value of type *GRPCProviderServer) as tfprotov5.ProviderServer value in return statement: *GRPCProviderServer does not implement tfprotov5.ProviderServer (missing method CallFunction)
make: *** [tfgen_build_only] Error 1
```