### PR TITLE
Hackathon: dispatch SDK build to pulumi/pulumi-sdk repo

### DIFF
--- a/.github/workflows/dispatch_build_sdk.yml
+++ b/.github/workflows/dispatch_build_sdk.yml
@@ -1,0 +1,51 @@
+name: dispatch-build-sdk
+on:
+    workflow_dispatch:
+        inputs:
+            sdk_version:
+                description: 'SDK version to build'
+                required: true
+
+jobs:
+    prerequisites:
+        uses: ./.github/workflows/prerequisites.yml
+        secrets: inherit
+        with:
+          default_branch: ${{ github.event.repository.default_branch }}
+          is_pr: ${{ github.event_name == 'pull_request' }}
+          is_automated: ${{ github.actor == 'dependabot[bot]' }}
+
+    dispatch_sdk_build:
+        needs: prerequisites
+        runs-on: ubuntu-latest
+        steps:
+          - name: Checkout central SDK repo
+            uses: actions/checkout@v4
+            with:
+              repository: pulumi/pulumi-sdk
+              ref: main
+              path: pulumi-sdk
+          - name: Download bin
+            uses: ./.github/actions/download-bin
+          - name: Extract schema from plugin binary
+            run: |
+                mkdir -p pulumi-sdk/xyz 
+                pulumi package get-schema ./bin/pulumi-resource-xyz > pulumi-sdk/xyz/schema.json
+          - name: Create PR (no linked issue)
+            uses: peter-evans/create-pull-request@v3.12.0
+            id: cpr
+            with:
+              author: pulumi-bot <bot@pulumi.com>
+              base: main
+              body: This pull request was generated automatically by the dispatch-build-sdk workflow in the xyz repository.
+              branch: pulumi-bot/publish-sdk-xyz-${{ github.run_id}}
+              commit-message: Publish SDKs for pulumi-xyz
+              committer: pulumi-bot <bot@pulumi.com>
+              path: pulumi-sdk
+              labels: impact/no-changelog-required
+              title: Publish SDKs for pulumi-xyz version ${{ github.event.inputs.sdk_version }}
+              token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          - name: Check outputs
+            run: |
+              echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+              echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"


### PR DESCRIPTION
Hackathon project: Central SDK publishing

Adding a workflow to test dispatching the SDK building to `pulumi/pulumi-sdk` via a PR.