### PR TITLE
Test dispatch schema to pulumi/pulumi-sdk repo

### DIFF
--- a/.github/workflows/dispatch_build_sdk.yml
+++ b/.github/workflows/dispatch_build_sdk.yml
@@ -18,6 +18,8 @@ jobs:
     needs: prerequisites
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
       - name: Checkout central SDK repo
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Hackathon project: Central SDK publishing

Adding a workflow to test dispatching the SDK building to pulumi/pulumi-sdk via a PR.

Replaces https://github.com/pulumi/pulumi-xyz/pull/343