### PR TITLE
Enable freeing disk space

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -18,3 +18,8 @@ plugins:
     kind: converter
 releaseVerification:
   nodejs: examples/basic
+
+# Test that the disk cleaning works correctly - deleting things can be risky
+freeDiskSpaceBeforeBuild: true
+freeDiskSpaceBeforeTest: true
+freeDiskSpaceBeforeSdkBuild: true

--- a/.github/workflows/build_provider.yml
+++ b/.github/workflows/build_provider.yml
@@ -29,6 +29,13 @@ jobs:
           - os: windows
             arch: amd64
     steps:
+      # Run as first step so we don't delete things that have just been installed
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        with:
+          tool-cache: false
+          swap-storage: false
+          dotnet: false
       - name: Checkout Repo
         uses: actions/checkout@v4
       - name: Setup tools

--- a/.github/workflows/build_sdk.yml
+++ b/.github/workflows/build_sdk.yml
@@ -42,6 +42,13 @@ jobs:
         - go
         - java
     steps:
+      # Run as first step so we don't delete things that have just been installed
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        with:
+          tool-cache: false
+          swap-storage: false
+          dotnet: false
       - name: Checkout Repo
         uses: actions/checkout@v4
       - name: Cache examples generation

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,6 +134,13 @@ jobs:
     env:
       PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        tool-cache: false
+        swap-storage: false
+        dotnet: false
     - name: Checkout Repo
       uses: actions/checkout@v4
     - name: Setup tools

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -78,6 +78,13 @@ jobs:
     env:
       PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        tool-cache: false
+        swap-storage: false
+        dotnet: false
     - name: Checkout Repo
       uses: actions/checkout@v4
     - name: Setup tools

--- a/.github/workflows/prerequisites.yml
+++ b/.github/workflows/prerequisites.yml
@@ -44,6 +44,13 @@ jobs:
     outputs:
       version: ${{ steps.provider-version.outputs.version }}
     steps:
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        tool-cache: false
+        swap-storage: false
+        dotnet: false
     - name: Checkout Repo
       uses: actions/checkout@v4
     - uses: pulumi/provider-version-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,13 @@ jobs:
     env:
       PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        tool-cache: false
+        swap-storage: false
+        dotnet: false
     - name: Checkout Repo
       uses: actions/checkout@v4
     - name: Setup tools

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -111,6 +111,13 @@ jobs:
     env:
       PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        tool-cache: false
+        swap-storage: false
+        dotnet: false
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/upgrade-bridge.yml
+++ b/.github/workflows/upgrade-bridge.yml
@@ -57,6 +57,13 @@ jobs:
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        tool-cache: false
+        swap-storage: false
+        dotnet: false
     - name: Checkout Repo
       uses: actions/checkout@v4
     - name: Setup tools

--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -9,6 +9,13 @@ jobs:
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:
+      # Run as first step so we don't delete things that have just been installed
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        with:
+          tool-cache: false
+          swap-storage: false
+          dotnet: false
       - name: Checkout Repo
         uses: actions/checkout@v4
       - name: Setup tools


### PR DESCRIPTION
This is a common source of bugs as the deletion process can remove tools we actually need. Enabling this option in xyz ensures it's run as part of the ci-mgmt test before rollout.

- Related to https://github.com/pulumi/ci-mgmt/issues/1096