### PR TITLE
Do not invoke docs when publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,25 +138,6 @@ jobs:
           go.*
           go/**
           !*.tar.gz
-  create_docs_build:
-    name: create_docs_build
-    needs: publish_sdk
-    # Only run for non-prerelease, if the publish_go_sdk job was successful or skipped
-    if: inputs.isPrerelease == false
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dispatch Metadata build
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
-          repository: pulumi/registry
-          event-type: resource-provider
-          client-payload: |-
-            {
-              "project": "${{ github.repository }}",
-              "project-shortname": "xyz",
-              "ref": "${{ github.ref_name }}"
-            }
 
   clean_up_release_labels:
     name: Clean up release labels


### PR DESCRIPTION
This ends up creating errors when invoking the workflow to publish docs for this provider in registry. I am removing this stage from the workflow since we do not want to publish this and it ends up creating alerts when it fails to publish.