### PR TITLE
Add dad joke to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,7 @@ The following configuration points are available for the `xyz` provider:
 ## Reference
 
 For detailed reference documentation, please visit [the Pulumi registry](https://www.pulumi.com/registry/packages/xyz/api-docs/).
+
+---
+
+**Dad Joke Corner**: Why don't infrastructure engineers ever get lost? Because they always know their way around the cloud! ☁️


### PR DESCRIPTION
Added a delightful dad joke to the end of the README to bring some humor to the documentation. Because who doesn't need a good laugh when working with infrastructure? 

The joke is infrastructure-themed and fits well with the cloud provider context of the repository.