### PR TITLE
[DO NOT MERGE] test: shadow-gen diff (compare_sdk) pre-merge e2e for ci-mgmt#2300

### DIFF
--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -217,6 +217,22 @@ jobs:
     with:
       version: ${{ needs.prerequisites.outputs.version }}
 
+  # TEMPORARY (pre-merge test): ref pinned to the PR branch.
+  compare_sdk:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    name: compare_sdk
+    needs: prerequisites
+    uses: pulumi/ci-mgmt/.github/workflows/compare_sdk.yml@pose/chores/compare-sdk-ci-workflow-2282
+    permissions:
+      contents: read
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      languages: '["nodejs","python","dotnet","go","java"]'
+      runs-on: ubuntu-latest
+      mise-version: 2026.3.7
+      checkout-submodules: 'false'
+
   comment-notification:
     if: github.event_name == 'repository_dispatch'
     name: comment-notification

--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,13 @@ build_python: .make/build_python
 	@touch $@
 .PHONY: generate_python build_python
 
+# TEMPORARY (pre-merge test): shadow-gen diff target. Refs pinned to the PR
+# branch so the not-yet-merged compare-sdk command resolves. See pulumi/ci-mgmt#2300.
+compare_sdks: compare_sdk_nodejs compare_sdk_python compare_sdk_dotnet compare_sdk_go compare_sdk_java
+compare_sdk_%: .make/mise_install bin/$(CODEGEN) .make/schema | mise_env
+	GOPROXY=direct GOSUMDB=off go run github.com/pulumi/ci-mgmt/provider-ci@5c67225ff01a0a1c97db76ce8e1481ef79acc5ef compare-sdk --language $*
+.PHONY: compare_sdks
+
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}
 	rm -rf bin/*


### PR DESCRIPTION
Throwaway test PR to exercise the centralized `compare_sdk` reusable workflow proposed in pulumi/ci-mgmt#2300 before it merges. Both the reusable-workflow `uses:` and the `compare_sdk` Makefile target are pinned to the ci-mgmt PR branch (not `@master`) so the not-yet-merged workflow and `compare-sdk` command resolve. **Do not merge**; will be closed once the `compare_sdk` run is observed.