### PR TITLE
[DO NOT MERGE] test: shadow-gen diff compare_sdk e2e (version fix) for ci-mgmt#2300

### DIFF
--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -217,6 +217,22 @@ jobs:
     with:
       version: ${{ needs.prerequisites.outputs.version }}
 
+  # TEMPORARY (pre-merge test): ref pinned to the PR branch.
+  compare_sdk:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    name: compare_sdk
+    needs: prerequisites
+    uses: pulumi/ci-mgmt/.github/workflows/compare_sdk.yml@pose/chores/compare-sdk-ci-workflow-2282
+    permissions:
+      contents: read
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      languages: '["nodejs","python","dotnet","go","java"]'
+      runs-on: ubuntu-latest
+      mise-version: 2026.3.7
+      checkout-submodules: 'false'
+
   comment-notification:
     if: github.event_name == 'repository_dispatch'
     name: comment-notification

--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,13 @@ build_python: .make/build_python
 	@touch $@
 .PHONY: generate_python build_python
 
+# TEMPORARY (pre-merge test): shadow-gen diff target. Refs pinned to the PR
+# branch so the not-yet-merged compare-sdk command resolves. See pulumi/ci-mgmt#2300.
+compare_sdks: compare_sdk_nodejs compare_sdk_python compare_sdk_dotnet compare_sdk_go compare_sdk_java
+compare_sdk_%: .make/mise_install bin/$(CODEGEN) .make/schema | mise_env
+	GOPROXY=direct GOSUMDB=off go run github.com/pulumi/ci-mgmt/provider-ci@216aafe9c4758833f6d551549de870073ee4799f compare-sdk --language $*
+.PHONY: compare_sdks
+
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}
 	rm -rf bin/*


### PR DESCRIPTION
Throwaway test PR to re-validate the centralized `compare_sdk` workflow after the gen-sdk version fix (default `--version` to `PROVIDER_VERSION` so legacy and gen-sdk embed the same version). Refs pinned to the ci-mgmt stack (reusable workflow @branch, command @216aafe9c). **Do not merge**; closed once the run is observed. Supersedes the earlier #2430.