### PR TITLE
Describe xyz as a CI test provider rather than a cloud provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # XYZ Resource Provider
 
-The xyz Resource Provider lets you manage [xyz](http://example.com) resources.
+The xyz Resource Provider is a test provider used by Pulumi CI to exercise
+provider tooling. It manages no real cloud resources and is not intended for
+use in Pulumi programs.
+
+The install instructions below exist so that CI can exercise the published
+SDKs. They are not a recommendation to depend on this package.
 
 ## Installing
 

--- a/provider/cmd/pulumi-resource-xyz/schema.json
+++ b/provider/cmd/pulumi-resource-xyz/schema.json
@@ -1,6 +1,6 @@
 {
     "name": "xyz",
-    "description": "A Pulumi package for creating and managing xyz cloud resources.",
+    "description": "A test provider used by Pulumi CI to exercise provider tooling. It manages no real cloud resources and is not intended for use in Pulumi programs.",
     "keywords": [
         "pulumi",
         "xyz",
@@ -29,7 +29,7 @@
             "respectSchemaVersion": true
         },
         "nodejs": {
-            "packageDescription": "A Pulumi package for creating and managing xyz cloud resources.",
+            "packageDescription": "A test provider used by Pulumi CI to exercise provider tooling. It manages no real cloud resources and is not intended for use in Pulumi programs.",
             "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-xyz)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-xyz` repo](https://github.com/pulumi/pulumi-xyz/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-xyz` repo](https://github.com/terraform-providers/terraform-provider-xyz/issues).",
             "devDependencies": {
                 "@types/mime": "^2.0.0",

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -68,7 +68,8 @@ func Provider() tfbridge.ProviderInfo {
 		// for use in Pulumi programs
 		// e.g https://github.com/org/pulumi-provider-name/releases/
 		PluginDownloadURL: "",
-		Description:       "A test provider used by Pulumi CI to exercise provider tooling. It manages no real cloud resources and is not intended for use in Pulumi programs.",
+		Description: "A test provider used by Pulumi CI to exercise provider tooling. " +
+			"It manages no real cloud resources and is not intended for use in Pulumi programs.",
 		// category/cloud tag helps with categorizing the package in the Pulumi Registry.
 		// For all available categories, see `Keywords` in
 		// https://www.pulumi.com/docs/guides/pulumi-packages/schema/#package.

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -68,7 +68,7 @@ func Provider() tfbridge.ProviderInfo {
 		// for use in Pulumi programs
 		// e.g https://github.com/org/pulumi-provider-name/releases/
 		PluginDownloadURL: "",
-		Description:       "A Pulumi package for creating and managing xyz cloud resources.",
+		Description:       "A test provider used by Pulumi CI to exercise provider tooling. It manages no real cloud resources and is not intended for use in Pulumi programs.",
 		// category/cloud tag helps with categorizing the package in the Pulumi Registry.
 		// For all available categories, see `Keywords` in
 		// https://www.pulumi.com/docs/guides/pulumi-packages/schema/#package.

--- a/sdk/dotnet/Config/README.md
+++ b/sdk/dotnet/Config/README.md
@@ -1,1 +1,1 @@
-A Pulumi package for creating and managing xyz cloud resources.
+A test provider used by Pulumi CI to exercise provider tooling. It manages no real cloud resources and is not intended for use in Pulumi programs.

--- a/sdk/dotnet/Pulumi.Xyz.csproj
+++ b/sdk/dotnet/Pulumi.Xyz.csproj
@@ -4,7 +4,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi</Authors>
     <Company>Pulumi</Company>
-    <Description>A Pulumi package for creating and managing xyz cloud resources.</Description>
+    <Description>A test provider used by Pulumi CI to exercise provider tooling. It manages no real cloud resources and is not intended for use in Pulumi programs.</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://www.pulumi.com</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pulumi/pulumi-xyz</RepositoryUrl>

--- a/sdk/dotnet/README.md
+++ b/sdk/dotnet/README.md
@@ -1,1 +1,1 @@
-A Pulumi package for creating and managing xyz cloud resources.
+A test provider used by Pulumi CI to exercise provider tooling. It manages no real cloud resources and is not intended for use in Pulumi programs.

--- a/sdk/dotnet/Region/README.md
+++ b/sdk/dotnet/Region/README.md
@@ -1,1 +1,1 @@
-A Pulumi package for creating and managing xyz cloud resources.
+A test provider used by Pulumi CI to exercise provider tooling. It manages no real cloud resources and is not intended for use in Pulumi programs.

--- a/sdk/go/xyz/doc.go
+++ b/sdk/go/xyz/doc.go
@@ -1,2 +1,2 @@
-// A Pulumi package for creating and managing xyz cloud resources.
+// A test provider used by Pulumi CI to exercise provider tooling. It manages no real cloud resources and is not intended for use in Pulumi programs.
 package xyz

--- a/sdk/java/README.md
+++ b/sdk/java/README.md
@@ -1,1 +1,1 @@
-A Pulumi package for creating and managing xyz cloud resources.
+A test provider used by Pulumi CI to exercise provider tooling. It manages no real cloud resources and is not intended for use in Pulumi programs.

--- a/sdk/java/build.gradle
+++ b/sdk/java/build.gradle
@@ -12,7 +12,7 @@ group = "com.pulumi"
 
 def resolvedVersion = System.getenv("PACKAGE_VERSION") ?:
     (project.version == "unspecified"
-         ? "1.2.0-alpha.1783767104+a0a3b62"
+         ? "1.0.0-alpha.0+dev"
          : project.version)
 
 def signingKey = System.getenv("SIGNING_KEY")
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = "2022"
                 name = "pulumi-xyz"
                 packaging = "jar"
-                description = $/A Pulumi package for creating and managing xyz cloud resources./$
+                description = $/A test provider used by Pulumi CI to exercise provider tooling. It manages no real cloud resources and is not intended for use in Pulumi programs./$
 
                 url = "https://github.com/pulumi/pulumi-xyz"
 

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@pulumi/xyz",
     "version": "1.0.0-alpha.0+dev",
-    "description": "A Pulumi package for creating and managing xyz cloud resources.",
+    "description": "A test provider used by Pulumi CI to exercise provider tooling. It manages no real cloud resources and is not intended for use in Pulumi programs.",
     "keywords": [
         "pulumi",
         "xyz",

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,6 +1,11 @@
 # XYZ Resource Provider
 
-The xyz Resource Provider lets you manage [xyz](http://example.com) resources.
+The xyz Resource Provider is a test provider used by Pulumi CI to exercise
+provider tooling. It manages no real cloud resources and is not intended for
+use in Pulumi programs.
+
+The install instructions below exist so that CI can exercise the published
+SDKs. They are not a recommendation to depend on this package.
 
 ## Installing
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_xyz"
-  description = "A Pulumi package for creating and managing xyz cloud resources."
+  description = "A test provider used by Pulumi CI to exercise provider tooling. It manages no real cloud resources and is not intended for use in Pulumi programs."
   dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   keywords = ["pulumi", "xyz", "category/cloud"]
   readme = "README.md"


### PR DESCRIPTION
`xyz` is a test provider used by Pulumi CI to exercise provider tooling, but its package description read "A Pulumi package for creating and managing xyz cloud resources.", which reads as a real cloud provider wherever SDK metadata surfaces. This sets the description to say what the provider actually is.

Regenerated with `make tfgen` and `make generate_sdks`. The rest of the diff is that one string propagating into the per-language SDK metadata.

Part of #2723

🤖 Generated with [Claude Code](https://claude.com/claude-code)
